### PR TITLE
Truncateの無効化とDeleteの連打無効化とファイルの比較を絶対パスで行うように変更

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -70,6 +70,8 @@ type Tail struct {
 	changes *watch.FileChanges
 
 	tomb.Tomb // provides: Done, Kill, Dying
+
+	lastDelChReceived time.Time // Last delete channel received time
 }
 
 var (
@@ -307,6 +309,13 @@ func (tail *Tail) waitForChanges() error {
 	case <-tail.changes.Modified:
 		return nil
 	case <-tail.changes.Deleted:
+		now := time.Now()
+		defer func() {
+			tail.lastDelChReceived = now
+		}()
+		if !tail.lastDelChReceived.Before(now.Add(-1 * time.Second)) {
+			return nil
+		}
 		tail.changes = nil
 		if tail.ReOpen {
 			// XXX: we must not log from a library.
@@ -322,13 +331,6 @@ func (tail *Tail) waitForChanges() error {
 			return ErrStop
 		}
 	case <-tail.changes.Truncated:
-		// Always reopen truncated files (Follow is true)
-		tail.Logger.Printf("Re-opening truncated file %s ...", tail.Filename)
-		if err := tail.reopen(); err != nil {
-			return err
-		}
-		tail.Logger.Printf("Successfully reopened truncated %s", tail.Filename)
-		tail.openReader()
 		return nil
 	case <-tail.Dying():
 		return ErrStop

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -46,7 +46,16 @@ func (fw *InotifyFileWatcher) BlockUntilExists(t *tomb.Tomb) error {
 		case evt, ok := <-fw.w.Event:
 			if !ok {
 				return fmt.Errorf("inotify watcher has been closed")
-			} else if evt.Name == fw.Filename {
+			}
+			evtName, err := filepath.Abs(evt.Name)
+			if err != nil {
+				return err
+			}
+			fwFilename, err := filepath.Abs(fw.Filename)
+			if err != nil {
+				return err
+			}
+			if evtName == fwFilename {
 				return nil
 			}
 		case <-t.Dying():


### PR DESCRIPTION
- Truncateの無効化
  audit.logのローテートのタイミングでtruncateが多発していたが、
  そもそも `cat /dev/null > /path/to/log` と人為的にやらない限り
  truncateは起こり得ないので無効化した。
- Deleteの連打無効化
  稀にローテートのタイミングでdeleteのチャネルが連続して飛んでくるが、
  前回のdeleteのチャネルを受信して1秒以内だった場合にはnilを返すようにした。
- ActiveState/tailのgotailで、 `-F 相対パス` をオプションに指定した時に、
  followしてくれない問題があったので、絶対パスでファイル情報を比較するようにした。
